### PR TITLE
Dockerfile updates for better dev/build times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,24 @@
 FROM debian:buster-slim as buildstage
 LABEL maintainer="Utsav Mishra <https://festivitymishra.github.io/>"
 
-# Install dependencies and Google tesseract
+# Install OS dependencies and Google tesseract
 RUN apt-get update && \
     apt-get install -y git pkg-config && \
     apt-get install -y libsm6 libxext6 libxrender-dev && \
+    apt-get install -y cmake && \
     apt-get install -y python-pip && \
     apt-get install -y tesseract-ocr && \
     apt-get install -y libtesseract-dev
 
-
-# Build Python APP Here
-RUN mkdir aadhaar_ocr_masking
-
-
-COPY Aadhaar.py /aadhaar_ocr_masking/Aadhaar.py
-COPY app.py /aadhaar_ocr_masking/app.py
-COPY requirements.txt /aadhaar_ocr_masking/requirements.txt
-
-RUN cd aadhaar_ocr_masking && \
-    pip install -r requirements.txt
-
+# Create and set working directory for Python app
 WORKDIR /aadhaar_ocr_masking
+
+# Install pip dependencies
+COPY requirements.txt requirements.txt
+RUN python -m pip install -r requirements.txt
+
+# Copy project files to workdir
+COPY Aadhaar.py app.py ./
 
 CMD ["python", "app.py"]
 


### PR DESCRIPTION
- Rearranged Dockerfile commands to install dependencies only when
dependencies change.
  - As it was earlier, the pip dependencies were reinstalled after every
  change in code (.py) files, which was completely unnecessary

- Added Cmake as an OS dependency as builds were failing without it

Tested to build successfully locally.

Related to #10